### PR TITLE
MRC-1670: Add model endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,10 @@ Imports:
     pkgapi (>= 0.0.8),
     traduire (>= 0.0.5)
 Suggests:
+    ids,
     mockery,
     R6,
     redux,
     testthat,
-    withr
+    withr,
+    zip

--- a/R/api.R
+++ b/R/api.R
@@ -10,6 +10,7 @@ api_build <- function(queue) {
   api$handle(endpoint_model_status(queue))
   api$handle(endpoint_model_result(queue))
   api$handle(endpoint_model_cancel(queue))
+  api$handle(endpoint_model_debug(queue))
   api$handle(endpoint_plotting_metadata())
   api$handle(endpoint_download_spectrum(queue))
   api$handle(endpoint_download_spectrum_head(queue))
@@ -179,6 +180,13 @@ endpoint_model_cancel <- function(queue) {
                               model_cancel(queue),
                               returning = response,
                               validate = TRUE)
+}
+
+endpoint_model_debug <- function(queue) {
+  pkgapi::pkgapi_endpoint$new("GET",
+                              "/model/debug/<id>",
+                              download_debug(queue),
+                              returning = pkgapi::pkgapi_returning_binary())
 }
 
 endpoint_plotting_metadata <- function() {

--- a/R/api.R
+++ b/R/api.R
@@ -6,6 +6,7 @@ api_build <- function(queue) {
   api$handle(endpoint_validate_survey_programme())
   api$handle(endpoint_model_submit(queue))
   api$handle(endpoint_model_status(queue))
+  api$handle(endpoint_model_result(queue))
   api$handle(endpoint_plotting_metadata())
   api$handle(endpoint_download_spectrum(queue))
   api$handle(endpoint_download_spectrum_head(queue))
@@ -106,6 +107,16 @@ endpoint_model_status <- function(queue) {
   pkgapi::pkgapi_endpoint$new("GET",
                               "/model/status/<id>",
                               model_status(queue),
+                              returning = response,
+                              validate = TRUE)
+}
+
+endpoint_model_result <- function(queue) {
+  response <- pkgapi::pkgapi_returning_json("ModelResultResponse.schema",
+                                            schema_root())
+  pkgapi::pkgapi_endpoint$new("GET",
+                              "/model/result/<id>",
+                              model_result(queue),
                               returning = response,
                               validate = TRUE)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -9,6 +9,7 @@ api_build <- function(queue) {
   api$handle(endpoint_model_submit(queue))
   api$handle(endpoint_model_status(queue))
   api$handle(endpoint_model_result(queue))
+  api$handle(endpoint_model_cancel(queue))
   api$handle(endpoint_plotting_metadata())
   api$handle(endpoint_download_spectrum(queue))
   api$handle(endpoint_download_spectrum_head(queue))
@@ -166,6 +167,16 @@ endpoint_model_result <- function(queue) {
   pkgapi::pkgapi_endpoint$new("GET",
                               "/model/result/<id>",
                               model_result(queue),
+                              returning = response,
+                              validate = TRUE)
+}
+
+endpoint_model_cancel <- function(queue) {
+  response <- pkgapi::pkgapi_returning_json("ModelCancelResponse.schema",
+                                            schema_root())
+  pkgapi::pkgapi_endpoint$new("GET",
+                              "/model/cancel/<id>",
+                              model_cancel(queue),
                               returning = response,
                               validate = TRUE)
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -140,6 +140,18 @@ model_result <- function(queue) {
   }
 }
 
+model_cancel <- function(queue) {
+  function(id) {
+    tryCatch({
+      queue$cancel(id)
+      json_null()
+    },
+    error = function(e) {
+      pkgapi::pkgapi_stop(e$message, "FAILED_TO_CANCEL")
+    })
+  }
+}
+
 plotting_metadata <- function(iso3) {
   tryCatch(
     hintr:::do_plotting_metadata(iso3),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,3 +4,7 @@ NULL
 .onLoad <- function(...) {
   hintr:::hintr_init_traduire() # nocov
 }
+
+tr_ <- function(...) {
+  t_(..., package = "hintr")
+}

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -17,7 +17,7 @@ MockQueue <- R6::R6Class(
   )
 )
 
-test_queue <- function(workers = 2) {
+test_queue <- function(workers = 0) {
   queue <- hintr:::Queue$new(workers = workers)
   withr::defer_parent({
     message("cleaning up workers")

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -17,8 +17,8 @@ MockQueue <- R6::R6Class(
   )
 )
 
-test_queue <- function() {
-  queue <- hintr:::Queue$new()
+test_queue <- function(workers = 2) {
+  queue <- hintr:::Queue$new(workers = workers)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -446,6 +446,59 @@ test_that("api can call endpoint_model_status", {
   expect_false(body$data$progress[2, "complete"])
 })
 
+test_that("endpoint_model_result can be run", {
+  test_redis_available()
+  test_mock_model_available()
+  queue <- test_queue()
+  model_run <- endpoint_model_submit(queue)
+  path <- setup_submit_payload()
+  run_response <- model_run$run(readLines(path))
+  expect_equal(run_response$status_code, 200)
+  expect_true(!is.null(run_response$data$id))
+
+  endpoint <- endpoint_model_result(queue)
+  out <- queue$queue$task_wait(run_response$data$id)
+  response <- endpoint$run(run_response$data$id)
+
+  expect_equal(response$status_code, 200)
+  expect_equal(names(response$data), c("data", "plottingMetadata"))
+  expect_equal(colnames(response$data$data),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(nrow(response$data$data) > 84042)
+  expect_equal(names(response$data$plottingMetadata),
+               c("barchart", "choropleth"))
+})
+
+test_that("api can call endpoint_model_result", {
+  test_redis_available()
+  test_mock_model_available()
+  queue <- test_queue()
+  api <- api_build(queue)
+  path <- setup_submit_payload()
+  res <- api$request("POST", "/model/submit",
+                     body = readLines(path))
+  expect_equal(res$status, 200)
+  body <- jsonlite::fromJSON(res$body)
+  expect_equal(body$status, "success")
+  expect_true(!is.null(body$data$id))
+
+  out <- queue$queue$task_wait(body$data$id)
+  res <- api$request("GET", sprintf("/model/result/%s", body$data$id))
+  expect_equal(res$status, 200)
+  body <- jsonlite::fromJSON(res$body)
+
+  expect_equal(body$status, "success")
+  expect_null(body$errors)
+  expect_equal(names(body$data), c("data", "plottingMetadata"))
+  expect_equal(colnames(body$data$data),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(nrow(body$data$data) > 84042)
+  expect_equal(names(body$data$plottingMetadata),
+               c("barchart", "choropleth"))
+})
+
 test_that("endpoint_plotting_metadata can be run", {
   endpoint <- endpoint_plotting_metadata()
   response <- endpoint$run("MWI")

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -392,7 +392,7 @@ test_that("api can call endpoint_model_submit", {
 test_that("endpoint_model_status can be run", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_run <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- model_run$run(readLines(path))
@@ -418,7 +418,7 @@ test_that("endpoint_model_status can be run", {
 test_that("api can call endpoint_model_status", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
   path <- setup_submit_payload()
   res <- api$request("POST", "/model/submit",
@@ -449,7 +449,7 @@ test_that("api can call endpoint_model_status", {
 test_that("endpoint_model_result can be run", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_run <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- model_run$run(readLines(path))
@@ -473,7 +473,7 @@ test_that("endpoint_model_result can be run", {
 test_that("api can call endpoint_model_result", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
   path <- setup_submit_payload()
   res <- api$request("POST", "/model/submit",
@@ -502,7 +502,7 @@ test_that("api can call endpoint_model_result", {
 test_that("endpoint_model_cancel can be run", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_run <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- model_run$run(readLines(path))
@@ -516,10 +516,10 @@ test_that("endpoint_model_cancel can be run", {
   expect_equal(response$data, json_null())
 })
 
-test_that("api can call endpoint_model_result", {
+test_that("api can call endpoint_model_cancel", {
   test_redis_available()
   test_mock_model_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
   path <- setup_submit_payload()
   res <- api$request("POST", "/model/submit",
@@ -594,7 +594,7 @@ test_that("endpoint_download_spectrum can be run", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   run_endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- run_endpoint$run(readLines(path))
@@ -621,7 +621,7 @@ test_that("api can call endpoint_download_spectrum", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
 
   ## Run the model
@@ -653,7 +653,7 @@ test_that("endpoint_download_summary can be run", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   run_endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- run_endpoint$run(readLines(path))
@@ -681,7 +681,7 @@ test_that("api can call endpoint_download_summary", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
 
   ## Run the model
@@ -721,7 +721,7 @@ test_that("endpoint_download_spectrum_head returns headers only", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   run_endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- run_endpoint$run(readLines(path))
@@ -742,7 +742,7 @@ test_that("api endpoint_download_spectrum_head returns headers only", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
 
   ## Run the model
@@ -768,7 +768,7 @@ test_that("endpoint_download_summary_head returns headers only", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   run_endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- run_endpoint$run(readLines(path))
@@ -790,7 +790,7 @@ test_that("api endpoint_download_summary_head returns headers only", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
 
   ## Run the model
@@ -817,7 +817,7 @@ test_that("endpoint_model_debug can be run", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   run_endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   run_response <- run_endpoint$run(readLines(path))
@@ -838,7 +838,7 @@ test_that("api can call endpoint_model_debug", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   api <- api_build(queue)
 
   ## Run the model

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -8,7 +8,7 @@ test_that("indicator download returns bytes", {
   path <- setup_submit_payload()
 
   ## Run the model
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))
@@ -29,7 +29,7 @@ test_that("spectrum download returns bytes", {
   path <- setup_submit_payload()
 
   ## Run the model
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))
@@ -54,7 +54,7 @@ test_that("download returns useful error if model run fails", {
 
   ## Run the model
   withr::with_envvar(c("USE_MOCK_MODEL" = "false"), {
-    queue <- test_queue()
+    queue <- test_queue(workers = 1)
     model_submit <- submit_model(queue)
     response <- model_submit(readLines(path))
     expect_true("id" %in% names(response))

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -8,7 +8,7 @@ test_that("endpoint model run queues a model run", {
   path <- setup_submit_payload()
 
   ## Call the endpoint
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))
@@ -146,7 +146,7 @@ test_that("running model with old version throws an error", {
                                }')
 
   ## Call the endpoint
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   error <- expect_error(model_submit(readLines(path)))
 
@@ -198,7 +198,7 @@ test_that("querying for result of missing job returns useful error", {
 test_that("querying for an orphan task returns sensible error", {
   test_redis_available()
 
-  queue <- test_queue(workers = 0)
+  queue <- test_queue()
   id <- ids::random_id()
   queue$queue$con$HSET(queue$queue$keys$task_status, id, "ORPHAN")
   get_model_result <- model_result(queue)
@@ -215,7 +215,7 @@ test_that("querying for result of incomplete jobs returns useful error", {
   test_mock_model_available()
 
   path <- setup_submit_payload()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))
@@ -295,7 +295,7 @@ test_that("model run can be cancelled", {
 
   ## Start the model running
   path <- setup_submit_payload()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))
@@ -359,7 +359,7 @@ test_that("Debug endpoint returns debug information", {
 
   ## Start the model running
   path <- setup_submit_payload()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   model_submit <- submit_model(queue)
   response <- model_submit(readLines(path))
   expect_true("id" %in% names(response))

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -29,98 +29,90 @@ test_that("endpoint model run queues a model run", {
   expect_equal(status$progress[[2]]$name, scalar("Finished mock model"))
   expect_false(status$progress[[2]]$complete)
 
-  # ## Get the result
-  # res <- MockPlumberResponse$new()
-  # model_result <- endpoint_model_result(queue)
-  # result <- model_result(NULL, res, status$data$id)
-  # result <- jsonlite::parse_json(result)
-  # expect_equal(res$status, 200)
-  # expect_equal(names(result$data), c("data", "plottingMetadata"))
-  # expect_equal(names(result$data$data[[1]]),
-  #              c("area_id", "sex", "age_group", "calendar_quarter",
-  #                "indicator_id", "mode", "mean", "lower", "upper"))
-  # expect_true(length(result$data$data) > 84042)
-  # expect_equal(names(result$data$plottingMetadata), c("barchart", "choropleth"))
-  #
-  #
-  # ## Barchart
-  # barchart <- result$data$plottingMetadata$barchart
-  # expect_equal(names(barchart), c("indicators", "filters", "defaults"))
-  # expect_length(barchart$filters, 4)
-  # expect_equal(names(barchart$filters[[1]]),
-  #              c("id", "column_id", "label", "options", "use_shape_regions"))
-  # expect_equal(names(barchart$filters[[2]]),
-  #              c("id", "column_id", "label", "options"))
-  # ## Choropleth has the correct filters in correct order
-  # filters <- lapply(barchart$filters, function(filter) {
-  #   filter$column_id
-  # })
-  # expect_equal(filters[[1]], "area_id")
-  # expect_equal(filters[[2]], "calendar_quarter")
-  # expect_equal(filters[[3]], "sex")
-  # expect_equal(filters[[4]], "age_group")
-  # expect_length(barchart$filters[[2]]$options, 3)
-  # expect_equal(barchart$filters[[2]]$options[[2]]$id, "CY2018Q3")
-  # expect_equal(barchart$filters[[2]]$options[[2]]$label, "September 2018")
-  # expect_true(length(barchart$filters[[4]]$options) >= 29)
-  # expect_length(barchart$indicators, 10)
-  #
-  # ## Quarters are in descending order
-  # calendar_quarters <-
-  #   lapply(barchart$filters[[2]]$options, function(option) {
-  #     option$id
-  #   })
-  # expect_equal(unlist(calendar_quarters),
-  #              sort(unlist(calendar_quarters), decreasing = TRUE))
-  #
-  #
-  # ## Barchart indicators are in numeric id order
-  # indicators <- lapply(barchart$indicators, function(indicator) {
-  #   indicator$indicator
-  # })
-  # expect_equal(unlist(indicators),
-  #              c("population", "prevalence", "plhiv", "art_coverage",
-  #                "current_art", "receiving_art", "incidence", "new_infections",
-  #                "anc_prevalence", "anc_art_coverage"))
-  #
-  # ## Choropleth
-  # choropleth <- result$data$plottingMetadata$choropleth
-  # expect_equal(names(choropleth), c("indicators", "filters"))
-  # expect_length(choropleth$filters, 4)
-  # expect_equal(names(choropleth$filters[[1]]),
-  #              c("id", "column_id", "label", "options", "use_shape_regions"))
-  # expect_equal(names(choropleth$filters[[2]]),
-  #              c("id", "column_id", "label", "options"))
-  # ## Choropleth has the correct filters in correct order
-  # filters <- lapply(choropleth$filters, function(filter) {
-  #   filter$column_id
-  # })
-  # expect_equal(filters[[1]], "area_id")
-  # expect_equal(filters[[2]], "calendar_quarter")
-  # expect_equal(filters[[3]], "sex")
-  # expect_equal(filters[[4]], "age_group")
-  # expect_length(choropleth$filters[[2]]$options, 3)
-  # expect_equal(choropleth$filters[[2]]$options[[2]]$id, "CY2018Q3")
-  # expect_equal(choropleth$filters[[2]]$options[[2]]$label, "September 2018")
-  # expect_true(length(choropleth$filters[[4]]$options) >= 29)
-  # expect_length(choropleth$indicators, 10)
-  #
-  # ## Quarters are in descending order
-  # calendar_quarters <-
-  #   lapply(choropleth$filters[[2]]$options, function(option) {
-  #     option$id
-  #   })
-  # expect_equal(unlist(calendar_quarters),
-  #              sort(unlist(calendar_quarters), decreasing = TRUE))
-  #
-  # ## Choropleth indicators are in numeric id order
-  # indicators <- lapply(choropleth$indicators, function(indicator) {
-  #   indicator$indicator
-  # })
-  # expect_equal(unlist(indicators),
-  #              c("population", "prevalence", "plhiv", "art_coverage",
-  #                "current_art", "receiving_art", "incidence", "new_infections",
-  #                "anc_prevalence", "anc_art_coverage"))
+  ## Get the result
+  get_model_result <- model_result(queue)
+  expect_equal(names(result), c("data", "plottingMetadata"))
+  expect_equal(colnames(result$data),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(nrow(result$data) > 84042)
+  expect_equal(names(result$plottingMetadata), c("barchart", "choropleth"))
+
+
+  ## Barchart
+  barchart <- result$plottingMetadata$barchart
+  expect_equal(names(barchart), c("indicators", "filters", "defaults"))
+  expect_length(barchart$filters, 4)
+  expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
+               c("id", "column_id", "label", "options"))
+  ## Choropleth has the correct filters in correct order
+  filters <- lapply(barchart$filters, function(filter) {
+    filter$column_id
+  })
+  expect_equal(filters[[1]], scalar("area_id"))
+  expect_equal(filters[[2]], scalar("calendar_quarter"))
+  expect_equal(filters[[3]], scalar("sex"))
+  expect_equal(filters[[4]], scalar("age_group"))
+  expect_length(barchart$filters[[2]]$options, 3)
+  expect_equal(barchart$filters[[2]]$options[[2]]$id, scalar("CY2018Q3"))
+  expect_equal(barchart$filters[[2]]$options[[2]]$label,
+               scalar("September 2018"))
+  expect_true(length(barchart$filters[[4]]$options) >= 29)
+  expect_equal(nrow(barchart$indicators), 10)
+
+  ## Quarters are in descending order
+  calendar_quarters <-
+    lapply(barchart$filters[[2]]$options, function(option) {
+      option$id
+    })
+  expect_equal(unlist(calendar_quarters),
+               sort(unlist(calendar_quarters), decreasing = TRUE))
+
+
+  ## Barchart indicators are in numeric id order
+  expect_equal(barchart$indicators$indicator,
+               c("population", "prevalence", "plhiv", "art_coverage",
+                 "current_art", "receiving_art", "incidence", "new_infections",
+                 "anc_prevalence", "anc_art_coverage"))
+
+  ## Choropleth
+  choropleth <- result$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 4)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
+               c("id", "column_id", "label", "options"))
+  ## Choropleth has the correct filters in correct order
+  filters <- lapply(choropleth$filters, function(filter) {
+    filter$column_id
+  })
+  expect_equal(filters[[1]], scalar("area_id"))
+  expect_equal(filters[[2]], scalar("calendar_quarter"))
+  expect_equal(filters[[3]], scalar("sex"))
+  expect_equal(filters[[4]], scalar("age_group"))
+  expect_length(choropleth$filters[[2]]$options, 3)
+  expect_equal(choropleth$filters[[2]]$options[[2]]$id, scalar("CY2018Q3"))
+  expect_equal(choropleth$filters[[2]]$options[[2]]$label,
+               scalar("September 2018"))
+  expect_true(length(choropleth$filters[[4]]$options) >= 29)
+  expect_equal(nrow(choropleth$indicators), 10)
+
+  ## Quarters are in descending order
+  calendar_quarters <-
+    lapply(choropleth$filters[[2]]$options, function(option) {
+      option$id
+    })
+  expect_equal(unlist(calendar_quarters),
+               sort(unlist(calendar_quarters), decreasing = TRUE))
+
+  ## Choropleth indicators are in numeric id order
+  expect_equal(choropleth$indicators$indicator,
+               c("population", "prevalence", "plhiv", "art_coverage",
+                 "current_art", "receiving_art", "incidence", "new_infections",
+                 "anc_prevalence", "anc_art_coverage"))
 })
 
 test_that("endpoint_run_model returns error if queueing fails", {
@@ -191,6 +183,84 @@ test_that("endpoint_run_status returns error if query for status fails", {
   expect_equal(error$status_code, 400)
 })
 
+test_that("querying for result of missing job returns useful error", {
+  test_redis_available()
+
+  queue <- hintr:::Queue$new()
+  get_model_result <- model_result(queue)
+  error <- expect_error(get_model_result("ID"))
+  expect_equal(error$data[[1]]$error, scalar("FAILED_TO_RETRIEVE_RESULT"))
+  expect_equal(error$data[[1]]$detail, scalar("Failed to fetch result"))
+  expect_equal(error$status_code, 400)
+})
+
+test_that("querying for an orphan task returns sensible error", {
+  test_redis_available()
+  res <- MockPlumberResponse$new()
+  queue <- Queue$new(workers = 0)
+  model_result <- endpoint_model_result(queue)
+
+  id <- ids::random_id()
+  queue$queue$con$HSET(queue$queue$keys$task_status, id, "ORPHAN")
+
+  result <- jsonlite::parse_json(model_result(NULL, res, id))
+  expect_equal(res$status, 400)
+  expect_equal(result$status, "failure")
+  expect_length(result$data, 0)
+  expect_length(result$errors, 1)
+  expect_equal(result$errors[[1]]$error, "MODEL_RUN_FAILED")
+  expect_equal(result$errors[[1]]$detail,
+               "Worker has crashed - error details are unavailable")
+})
+
+test_that("querying for result of incomplete jobs returns useful error", {
+  test_redis_available()
+  data <- list(
+    pjnz = list(path = "path/to/pjnz", hash = "12345", filename = "original"),
+    shape = list(path = "path/to/shape", hash = "12345",  filename = "original"),
+    population = list(path = "path/to/pop", hash = "12345", filename = "original"),
+    survey = list(path = "path/to/survey", hash = "12345", filename = "original"),
+    programme = list(path = "path/to/programme", hash = "12345", filename = "original"),
+    anc = list(path = "path/to/anc", hash = "12345", filename = "original")
+  )
+  options = list()
+  req <- list(postBody = '
+              {
+              "data": {
+              "pjnz": {"path":"path/to/file","hash": "12345","filename":"original"}
+              "shape":  {"path":"path/to/file","hash": "12345","filename":"original"},
+              "population":  {"path":"path/to/file","hash": "12345","filename":"original"},
+              "survey":  {"path":"path/to/file","hash": "12345","filename":"original"},
+              "programme":  {"path":"path/to/file","hash": "12345","filename":"original"},
+              "anc":  {"path":"path/to/file","hash": "12345","filename":"original"}
+              },
+              "options": {
+              "use_mock_model": true
+              }
+              }')
+
+  ## Create mock response
+  res <- MockPlumberResponse$new()
+
+  ## Call the endpoint
+  queue <- Queue$new()
+  model_submit <- endpoint_model_submit(queue)
+  response <- model_submit(req, res, data, options, cfg$version_info)
+  response <- jsonlite::parse_json(response)
+  expect_equal(response$status, "success")
+
+  ## Get result prematurely
+  model_result <- endpoint_model_result(queue)
+  result <- model_result(NULL, res, response$data$id)
+  result <- jsonlite::parse_json(result)
+  expect_equal(res$status, 400)
+  expect_equal(result$status, "failure")
+  expect_length(result$data, 0)
+  expect_length(result$errors, 1)
+  expect_equal(result$errors[[1]]$error, "FAILED_TO_RETRIEVE_RESULT")
+  expect_equal(result$errors[[1]]$detail, "Failed to fetch result")
+})
+
 test_that("erroring model run returns useful messages", {
   test_redis_available()
 
@@ -210,30 +280,30 @@ test_that("erroring model run returns useful messages", {
   expect_equal(status$success, scalar(FALSE))
   expect_equal(status$id, response$id)
 
-  ## Get the result
-  # model_result <- endpoint_model_result(queue)
-  # result <- model_result(req, res, response$data$id)
-  # result_parsed <- jsonlite::parse_json(result)
-  # expect_equal(res$status, 400)
-  #
-  # expect_equal(result_parsed$status, "failure")
-  # expect_length(result_parsed$data, 0)
-  # expect_length(result_parsed$errors, 1)
-  # expect_equal(result_parsed$errors[[1]]$error, "MODEL_RUN_FAILED")
-  # expect_equal(result_parsed$errors[[1]]$detail, "test error")
-  #
-  # trace <- vcapply(result_parsed$errors[[1]]$trace, identity)
-  # expect_true("rrq:::rrq_worker_main()" %in% trace)
-  # expect_true("stop(\"test error\")" %in% trace)
-  # expect_match(trace[[1]], "^# [[:xdigit:]]+$")
-  #
-  # ## Check logging:
-  # res$headers[["Content-Type"]] <- "application/json"
-  # res$body <- result
-  # res$status <- 400
-  # msg <- capture_messages(
-  #   api_log_end(NULL, NULL, res, NULL))
-  # expect_match(msg[[1]], "error-key: [a-z]{5}-[a-z]{5}-[a-z]{5}")
-  # expect_match(msg[[2]], "error-detail: test error")
-  # expect_match(msg[[3]], "error-trace: rrq:::rrq_worker_main")
+  # Get the result
+  model_result <- endpoint_model_result(queue)
+  result <- model_result(req, res, response$data$id)
+  result_parsed <- jsonlite::parse_json(result)
+  expect_equal(res$status, 400)
+
+  expect_equal(result_parsed$status, "failure")
+  expect_length(result_parsed$data, 0)
+  expect_length(result_parsed$errors, 1)
+  expect_equal(result_parsed$errors[[1]]$error, "MODEL_RUN_FAILED")
+  expect_equal(result_parsed$errors[[1]]$detail, "test error")
+
+  trace <- vcapply(result_parsed$errors[[1]]$trace, identity)
+  expect_true("rrq:::rrq_worker_main()" %in% trace)
+  expect_true("stop(\"test error\")" %in% trace)
+  expect_match(trace[[1]], "^# [[:xdigit:]]+$")
+
+  ## Check logging:
+  res$headers[["Content-Type"]] <- "application/json"
+  res$body <- result
+  res$status <- 400
+  msg <- capture_messages(
+    api_log_end(NULL, NULL, res, NULL))
+  expect_match(msg[[1]], "error-key: [a-z]{5}-[a-z]{5}-[a-z]{5}")
+  expect_match(msg[[2]], "error-detail: test error")
+  expect_match(msg[[3]], "error-trace: rrq:::rrq_worker_main")
 })

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -354,10 +354,8 @@ test_that("failed cancel sends reasonable message", {
 })
 
 test_that("Debug endpoint returns debug information", {
-  ## this one needs legit filenames available
   test_redis_available()
   test_mock_model_available()
-  ## Create request data
 
   ## Start the model running
   path <- setup_submit_payload()


### PR DESCRIPTION
* /model/result/
* /model/cancel/
* /model/debug/

I think we're going to have to do some pkgapi work to get `/model/result` working as it does in hintr. It returns the trace with the error which pkgapi doesn't currently support. See https://mrc-ide.myjetbrains.com/youtrack/issue/RESIDE-176

This has also highlighted the logging stuff which I expect will change with shift to pkgapi but I haven't been through worked this out yet. Ticket https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1683

I think both those things can be done in a separate PR