### PR TITLE
MRC-1672: Add backend endpoints

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -16,6 +16,7 @@ api_build <- function(queue) {
   api$handle(endpoint_download_spectrum_head(queue))
   api$handle(endpoint_download_summary(queue))
   api$handle(endpoint_download_summary_head(queue))
+  api$handle(endpoint_hintr_version())
   api
 }
 
@@ -234,4 +235,14 @@ endpoint_download_summary_head <- function(queue) {
                               download_summary(queue),
                               returning = returning_binary_head(),
                               validate = FALSE)
+}
+
+endpoint_hintr_version <- function() {
+  response <- pkgapi::pkgapi_returning_json("HintrVersionResponse.schema",
+                                            schema_root())
+  pkgapi::pkgapi_endpoint$new("GET",
+                              "/hintr/version",
+                              function() cfg$version_info,
+                              returning = response,
+                              validate = TRUE)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -18,6 +18,7 @@ api_build <- function(queue) {
   api$handle(endpoint_download_summary_head(queue))
   api$handle(endpoint_hintr_version())
   api$handle(endpoint_hintr_worker_status(queue))
+  api$handle(endpoint_hintr_stop(queue))
   api
 }
 
@@ -256,4 +257,18 @@ endpoint_hintr_worker_status <- function(queue) {
                               worker_status(queue),
                               returning = response,
                               validate = TRUE)
+}
+
+pkgapi_returning_null <- function() {
+  pkgapi::pkgapi_returning(content_type = "text/plain",
+                           process = function(data) NULL,
+                           validate = function(body) TRUE)
+}
+
+endpoint_hintr_stop <- function(queue) {
+  pkgapi::pkgapi_endpoint$new("POST",
+                              "/hintr/stop",
+                              hintr_stop(queue),
+                              returning = pkgapi_returning_null(),
+                              validate = FALSE)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -259,16 +259,17 @@ endpoint_hintr_worker_status <- function(queue) {
                               validate = TRUE)
 }
 
-pkgapi_returning_null <- function() {
-  pkgapi::pkgapi_returning(content_type = "text/plain",
-                           process = function(data) NULL,
-                           validate = function(body) TRUE)
-}
-
 endpoint_hintr_stop <- function(queue) {
+  ## This endpoint calls hintr_stop which kills any workers and then calls stop.
+  ## It will never return anything so this won't ever be called in production,
+  ## it exists only so that when we mock hintr_stop this returns without errors
+  ## so we can effectively test.
+  returning <- pkgapi::pkgapi_returning(content_type = "application/json",
+                                        process = function(data) json_null(),
+                                        validate = function(body) TRUE)
   pkgapi::pkgapi_endpoint$new("POST",
                               "/hintr/stop",
                               hintr_stop(queue),
-                              returning = pkgapi_returning_null(),
+                              returning = returning,
                               validate = FALSE)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -17,6 +17,7 @@ api_build <- function(queue) {
   api$handle(endpoint_download_summary(queue))
   api$handle(endpoint_download_summary_head(queue))
   api$handle(endpoint_hintr_version())
+  api$handle(endpoint_hintr_worker_status(queue))
   api
 }
 
@@ -243,6 +244,16 @@ endpoint_hintr_version <- function() {
   pkgapi::pkgapi_endpoint$new("GET",
                               "/hintr/version",
                               function() cfg$version_info,
+                              returning = response,
+                              validate = TRUE)
+}
+
+endpoint_hintr_worker_status <- function(queue) {
+  response <- pkgapi::pkgapi_returning_json("HintrWorkerStatus.schema",
+                                            schema_root())
+  pkgapi::pkgapi_endpoint$new("GET",
+                              "/hintr/worker/status",
+                              worker_status(queue),
                               returning = response,
                               validate = TRUE)
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -244,3 +244,9 @@ download_debug <- function(queue) {
     })
   }
 }
+
+worker_status <- function(queue) {
+  function() {
+    lapply(queue$queue$worker_status(), scalar)
+  }
+}

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -250,3 +250,13 @@ worker_status <- function(queue) {
     lapply(queue$queue$worker_status(), scalar)
   }
 }
+
+hintr_stop <- function(queue) {
+  force(queue)
+  function() {
+    message("Stopping workers")
+    queue$queue$worker_stop()
+    message("Quitting hintr")
+    quit(save = "no")
+  }
+}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -904,3 +904,28 @@ test_that("api can call endpoint_hintr_worker_status", {
 
   expect_equal(unlist(response$data, FALSE, FALSE), rep("IDLE", 2))
 })
+
+test_that("endpoint_hintr_stop works", {
+  test_redis_available()
+
+  queue <- test_queue(workers = 0)
+  mock_hintr_stop <- mockery::mock(function() NULL)
+  mockery::stub(endpoint_hintr_stop, "hintr_stop", mock_hintr_stop)
+  endpoint <- endpoint_hintr_stop(queue)
+  response <- endpoint$run()
+
+  mockery::expect_called(mock_hintr_stop, 1)
+})
+
+test_that("api can call endpoint_hintr_stop", {
+  test_redis_available()
+
+  queue <- test_queue(workers = 0)
+  mock_hintr_stop <- mockery::mock(function() NULL)
+  with_mock("hintr2:::hintr_stop" = mock_hintr_stop, {
+    api <- api_build(queue)
+    res <- api$request("POST", "/hintr/stop")
+  })
+  expect_equal(res$status, 200)
+  mockery::expect_called(mock_hintr_stop, 1)
+})

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -14,7 +14,9 @@ test_that("endpoint_baseline_individual", {
 })
 
 test_that("endpoint_baseline_individual works", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/validate/baseline-individual",
                      body = readLines("payload/validate_pjnz_payload.json"))
   expect_equal(res$status, 200)
@@ -36,7 +38,9 @@ test_that("endpoint_baseline_combined", {
 })
 
 test_that("endpoint_baseline_combined works", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/validate/baseline-combined",
                      body = readLines("payload/validate_baseline_payload.json"))
   expect_equal(res$status, 200)
@@ -60,7 +64,9 @@ test_that("endpoint_validate_survey_programme programme", {
 })
 
 test_that("endpoint_validate_survey_programme works with programme data", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/validate/survey-and-programme",
                      body =
                        readLines("payload/validate_programme_payload.json"))
@@ -90,7 +96,9 @@ test_that("endpoint_validate_survey_programme anc", {
 })
 
 test_that("endpoint_validate_survey_programme works with anc data", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/validate/survey-and-programme",
                      body = readLines("payload/validate_anc_payload.json"))
   expect_equal(res$status, 200)
@@ -119,7 +127,9 @@ test_that("endpoint_validate_survey_programme survey", {
 })
 
 test_that("endpoint_validate_survey_programme works with survey data", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/validate/survey-and-programme",
                      body = readLines("payload/validate_survey_payload.json"))
   expect_equal(res$status, 200)
@@ -237,7 +247,9 @@ test_that("endpoint_model_options", {
 })
 
 test_that("endpoint_model_options works", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("POST", "/model/options",
                      body = readLines("payload/model_run_options_payload.json"))
   expect_equal(res$status, 200)
@@ -549,7 +561,9 @@ test_that("endpoint_plotting_metadata can be run", {
 })
 
 test_that("api can call endpoint_plotting_metadata", {
-  api <- api_build()
+  test_redis_available()
+  queue <- test_queue(workers = 0)
+  api <- api_build(queue)
   res <- api$request("GET", "/meta/plotting/MWI")
   expect_equal(res$status, 200)
   body <- jsonlite::fromJSON(res$body)

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -859,3 +859,27 @@ test_that("api can call endpoint_model_debug", {
   ## Download contains data
   expect_true(length(res$body) > 1000000)
 })
+
+test_that("endpoint_hintr_version works", {
+  endpoint <- endpoint_hintr_version()
+  response <- endpoint$run()
+  response <- jsonlite::parse_json(response)
+
+  expect_is(response$data, "list")
+  expect_setequal(names(response$data), c("hintr", "naomi", "rrq", "traduire"))
+  expect_equal(response$data$rrq, scalar(as.character(packageVersion("rrq"))))
+})
+
+test_that("api can call endpoint_hintr_version", {
+  test_redis_available()
+
+  queue <- test_queue()
+  api <- api_build(queue)
+  res <- api$request("GET", "/hintr/version")
+  expect_equal(res$status, 200)
+  response <- jsonlite::fromJSON(res$body)
+
+  expect_is(response$data, "list")
+  expect_setequal(names(response$data), c("hintr", "naomi", "rrq", "traduire"))
+  expect_equal(response$data$rrq, as.character(packageVersion("rrq")))
+})

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -863,7 +863,6 @@ test_that("api can call endpoint_model_debug", {
 test_that("endpoint_hintr_version works", {
   endpoint <- endpoint_hintr_version()
   response <- endpoint$run()
-  response <- jsonlite::parse_json(response)
 
   expect_is(response$data, "list")
   expect_setequal(names(response$data), c("hintr", "naomi", "rrq", "traduire"))

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -882,3 +882,25 @@ test_that("api can call endpoint_hintr_version", {
   expect_setequal(names(response$data), c("hintr", "naomi", "rrq", "traduire"))
   expect_equal(response$data$rrq, as.character(packageVersion("rrq")))
 })
+
+test_that("endpoint_hintr_worker_status works", {
+  test_redis_available()
+
+  queue <- test_queue()
+  endpoint <- endpoint_hintr_worker_status(queue)
+  response <- endpoint$run()
+
+  expect_equal(unlist(response$data, FALSE, FALSE), rep("IDLE", 2))
+})
+
+test_that("api can call endpoint_hintr_worker_status", {
+  test_redis_available()
+
+  queue <- test_queue()
+  api <- api_build(queue)
+  res <- api$request("GET", "/hintr/worker/status")
+  expect_equal(res$status, 200)
+  response <- jsonlite::fromJSON(res$body)
+
+  expect_equal(unlist(response$data, FALSE, FALSE), rep("IDLE", 2))
+})

--- a/tests/testthat/test-endpoints-hintr.R
+++ b/tests/testthat/test-endpoints-hintr.R
@@ -1,0 +1,17 @@
+test_that("endpoint worker status works", {
+  test_redis_available()
+  queue <- test_queue()
+  status <- worker_status(queue)
+
+  response <- status()
+  expect_equal(unlist(response, FALSE, FALSE), rep("IDLE", 2))
+
+  queue$queue$worker_stop(timeout = 5)
+  Sys.sleep(5)
+  response <- status()
+  expect_equal(unlist(response, FALSE, FALSE), rep("EXITED", 2))
+
+  queue$queue$worker_delete_exited()
+  response <- status()
+  expect_equal(response, setNames(list(), character()))
+})


### PR DESCRIPTION
This PR will add endpoints
* /hintr/version
* /hintr/worker/status
* /hintr/stop

This builds on PR #5 and we should review after that one has been merged

`/hintr/version` and `/hintr/worker/status` are fairly straightforward. I think `/hintr/stop` might need something adding to pkgapi, currently kind of hacking in a "NULL" return type which ends up just returning a body with no content - and saying the return type is plain text. Probably not exactly what  we want - perhaps we need to let pkgapi have endpoints which don't return anything. Or maybe instead this endpoint should return some indication of success only.