### PR TITLE
MRC-1683: Return trace & key from errors on enable logging 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Additional_repositories: https://mrc-ide.github.io/drat
 Imports:
     hintr (>= 0.0.35),
     jsonlite (>= 1.2.2),
-    pkgapi (>= 0.0.8),
+    pkgapi (>= 0.0.9),
     traduire (>= 0.0.5)
 Suggests:
     ids,

--- a/R/api.R
+++ b/R/api.R
@@ -19,6 +19,8 @@ api_build <- function(queue) {
   api$handle(endpoint_hintr_version())
   api$handle(endpoint_hintr_worker_status(queue))
   api$handle(endpoint_hintr_stop(queue))
+  api$registerHook("preroute", hintr:::api_preroute)
+  api$registerHook("postserialize", hintr:::api_postserialize)
   api
 }
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -127,8 +127,7 @@ model_result <- function(queue) {
     } else if (task_status == "ERROR") {
       result <- queue$result(id)
       trace <- c(sprintf("# %s", id), result$trace)
-      error_data <- structure(result$message, trace = trace)
-      pkgapi::pkgapi_stop(error_data, "MODEL_RUN_FAILED")
+      hintr_error(result$message, "MODEL_RUN_FAILED", trace = trace)
     } else if (task_status == "ORPHAN") {
       pkgapi::pkgapi_stop(tr_("MODEL_RESULT_CRASH"), "MODEL_RUN_FAILED")
     } else if (task_status == "INTERRUPTED") {
@@ -156,7 +155,7 @@ plotting_metadata <- function(iso3) {
   tryCatch(
     hintr:::do_plotting_metadata(iso3),
     error = function(e) {
-      pkgapi::pkgapi_stop("FAILED_TO_GET_METADATA", e$message)
+      pkgapi::pkgapi_stop(e$message, "FAILED_TO_GET_METADATA")
     }
   )
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -16,7 +16,7 @@ validate_baseline <- function(input) {
     hintr:::input_response(validate_func(input$file), input$type, input$file)
   },
     error = function(e) {
-      pkgapi::pkgapi_stop(e$message, "INVALID_FILE")
+      hintr_error(e$message, "INVALID_FILE")
   })
 }
 
@@ -35,7 +35,7 @@ validate_baseline_combined <- function(input) {
                                  as_file_object(input$population))
   },
   error = function(e) {
-    pkgapi::pkgapi_stop(e$message, "INVALID_BASELINE")
+    hintr_error(e$message, "INVALID_BASELINE")
   })
 }
 
@@ -53,7 +53,7 @@ validate_survey_programme <- function(input) {
                            input$type, input$file)
   },
   error = function(e) {
-    pkgapi::pkgapi_stop(e$message, "INVALID_FILE")
+    hintr_error(e$message, "INVALID_FILE")
   })
 }
 
@@ -66,7 +66,7 @@ model_options <- function(input) {
       hintr:::do_endpoint_model_options(input$shape, input$survey,
                                         input$programme, input$anc))
   }, error = function(e) {
-    pkgapi::pkgapi_stop(e$message, "INVALID_OPTIONS")
+    hintr_error(e$message, "INVALID_OPTIONS")
   })
 }
 
@@ -85,7 +85,7 @@ model_options_validate <- function(input) {
     data <- naomi:::format_data_input(data)
     list(valid = scalar(naomi:::validate_model_options(data, input$options)))
   }, error = function(e) {
-    pkgapi::pkgapi_stop(e$message, "INVALID_OPTIONS")
+    hintr_error(e$message, "INVALID_OPTIONS")
   })
 }
 
@@ -93,13 +93,12 @@ submit_model <- function(queue) {
   function(input) {
     input <- jsonlite::fromJSON(input)
     if (!hintr:::is_current_version(input$version)) {
-      pkgapi::pkgapi_stop(tr_("MODEL_SUBMIT_OLD"),
-                          "VERSION_OUT_OF_DATE")
+      hintr_error(tr_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
     tryCatch(
       list(id = scalar(queue$submit(input$data, input$options))),
       error = function(e) {
-        pkgapi::pkgapi_stop(e$message, "FAILED_TO_QUEUE")
+        hintr_error(e$message, "FAILED_TO_QUEUE")
       }
     )
   }
@@ -114,7 +113,7 @@ model_status <- function(queue) {
       hintr:::prepare_status_response(out, id)
     },
     error = function(e) {
-      pkgapi::pkgapi_stop(e$message, "FAILED_TO_RETRIEVE_STATUS")
+      hintr_error(e$message, "FAILED_TO_RETRIEVE_STATUS")
     })
   }
 }
@@ -129,12 +128,11 @@ model_result <- function(queue) {
       trace <- c(sprintf("# %s", id), result$trace)
       hintr_error(result$message, "MODEL_RUN_FAILED", trace = trace)
     } else if (task_status == "ORPHAN") {
-      pkgapi::pkgapi_stop(tr_("MODEL_RESULT_CRASH"), "MODEL_RUN_FAILED")
+      hintr_error(tr_("MODEL_RESULT_CRASH"), "MODEL_RUN_FAILED")
     } else if (task_status == "INTERRUPTED") {
-      pkgapi::pkgapi_stop(tr_("MODEL_RUN_CANCELLED"), "MODEL_RUN_FAILED")
+      hintr_error(tr_("MODEL_RUN_CANCELLED"), "MODEL_RUN_FAILED")
     } else { # ~= MISSING, PENDING, RUNNING
-      pkgapi::pkgapi_stop(tr_("MODEL_RESULT_MISSING"),
-                          "FAILED_TO_RETRIEVE_RESULT")
+      hintr_error(tr_("MODEL_RESULT_MISSING"), "FAILED_TO_RETRIEVE_RESULT")
     }
   }
 }
@@ -146,7 +144,7 @@ model_cancel <- function(queue) {
       json_null()
     },
     error = function(e) {
-      pkgapi::pkgapi_stop(e$message, "FAILED_TO_CANCEL")
+      hintr_error(e$message, "FAILED_TO_CANCEL")
     })
   }
 }
@@ -155,7 +153,7 @@ plotting_metadata <- function(iso3) {
   tryCatch(
     hintr:::do_plotting_metadata(iso3),
     error = function(e) {
-      pkgapi::pkgapi_stop(e$message, "FAILED_TO_GET_METADATA")
+      hintr_error(e$message, "FAILED_TO_GET_METADATA")
     }
   )
 }
@@ -173,7 +171,7 @@ download <- function(queue, type, filename) {
     tryCatch({
       res <- queue$result(id)
       if (hintr:::is_error(res)) {
-        pkgapi::pkgapi_stop(res$message, "MODEL_RUN_FAILED")
+        hintr_error(res$message, "MODEL_RUN_FAILED")
       }
       path <- switch(type,
                      "spectrum" = res$spectrum_path,
@@ -190,7 +188,7 @@ download <- function(queue, type, filename) {
       if (is_pkgapi_error(e)) {
         stop(e)
       } else {
-        pkgapi::pkgapi_stop(e$message, "FAILED_TO_RETRIEVE_RESULT")
+        hintr_error(e$message, "FAILED_TO_RETRIEVE_RESULT")
       }
     })
   }
@@ -238,7 +236,7 @@ download_debug <- function(queue) {
       if (is_pkgapi_error(e)) {
         stop(e)
       } else {
-        pkgapi::pkgapi_stop(e$message, "INVALID_TASK")
+        hintr_error(e$message, "INVALID_TASK")
       }
     })
   }

--- a/R/errors.R
+++ b/R/errors.R
@@ -1,0 +1,5 @@
+hintr_error <- function(message, error, status_code = 400L, ...) {
+  key <- scalar(ids::proquint(n_words = 3))
+  pkgapi::pkgapi_stop(message, error, errors = NULL, status_code = status_code,
+                      key = key, ...)
+}

--- a/inst/schema/BarchartDefaults.schema.json
+++ b/inst/schema/BarchartDefaults.schema.json
@@ -8,15 +8,15 @@
     "selected_filter_options": {
       "type": "object",
       "patternProperties": {
-        "^.*$": { 
+        "^.*$": {
           "type": "array",
           "items": { "$ref": "FilterOption.schema.json" }
         }
       },
-      "additonalProperties": true,
+      "additionalProperties": true,
       "required": [ "area", "quarter", "age", "sex" ]
     }
   },
-  "additonalProperties": false,
+  "additionalProperties": false,
   "required": [ "indicator_id", "x_axis_id", "disaggregate_by_id", "selected_filter_options" ]
 }

--- a/inst/schema/BarchartIndicator.schema.json
+++ b/inst/schema/BarchartIndicator.schema.json
@@ -24,6 +24,6 @@
       "type": "string"
     }
   },
-  "additonalProperties": "false",
+  "additionalProperties": false,
   "required": [ "indicator", "value_column", "indicator_column", "indicator_value", "name", "error_low_column", "error_high_column" ]
 }

--- a/inst/schema/BarchartMetadata.schema.json
+++ b/inst/schema/BarchartMetadata.schema.json
@@ -12,6 +12,6 @@
     },
     "defaults": { "$ref": "BarchartDefaults.schema.json" }
   },
-  "additonalProperties": "false",
+  "additionalProperties": false,
   "required": [ "indicators", "filters" ]
 }

--- a/inst/schema/ChoroplethMetadata.schema.json
+++ b/inst/schema/ChoroplethMetadata.schema.json
@@ -11,6 +11,6 @@
       "items": { "$ref": "Filter.schema.json" }
     }
   },
-  "additonalProperties": "false",
+  "additionalProperties": false,
   "required": [ "indicators", "filters" ]
 }

--- a/inst/schema/Filter.schema.json
+++ b/inst/schema/Filter.schema.json
@@ -2,13 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "id": { 
+    "id": {
       "type": "string"
     },
-    "column_id": { 
+    "column_id": {
       "type": "string"
     },
-    "label": { 
+    "label": {
       "type": "string"
     },
     "options": {
@@ -19,6 +19,6 @@
       "type": [ "boolean", "null" ]
     }
   },
-  "additonalProperties": "false",
+  "additionalProperties": false,
   "required": [ "id", "column_id", "label", "options" ]
 }

--- a/inst/schema/ModelResultRow.schema.json
+++ b/inst/schema/ModelResultRow.schema.json
@@ -30,7 +30,7 @@
       "type": [ "number", "null" ]
     }
   },
-  "additonalProperties": true,
+  "additionalProperties": true,
   "required": [ "area_id", "sex", "age_group", "calendar_quarter", "indicator_id",
     "mode", "mean", "lower", "upper" ]
 }

--- a/inst/schema/SurveyDataRow.schema.json
+++ b/inst/schema/SurveyDataRow.schema.json
@@ -39,7 +39,7 @@
       "type": [ "number", "null" ]
     }
   },
-  "additonalProperties": true,
+  "additionalProperties": true,
   "required": [ "indicator", "survey_id", "area_id",
     "sex", "age_group", "n_cluster", "n_obs", "est", "se", "ci_l", "ci_u" ]
 }

--- a/tests/testthat/helper-hint2.R
+++ b/tests/testthat/helper-hint2.R
@@ -71,3 +71,14 @@ skip_if_sensitive_data_missing <- function() {
     skip("Sensitive data missing, check README for details.")
   }
 }
+
+MockQueue <- R6::R6Class(
+  "MockQueue",
+  inherit = Queue,
+  cloneable = FALSE,
+  public = list(
+    submit = function(data, options) {
+      self$queue$enqueue_(quote(stop("test error")))
+    }
+  )
+)

--- a/tests/testthat/test-endpoints-hintr.R
+++ b/tests/testthat/test-endpoints-hintr.R
@@ -1,6 +1,6 @@
 test_that("endpoint worker status works", {
   test_redis_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 2)
   status <- worker_status(queue)
 
   response <- status()

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -264,17 +264,6 @@ test_that("erroring model run returns useful messages", {
   expect_true("rrq:::rrq_worker_main()" %in% trace)
   expect_true("stop(\"test error\")" %in% trace)
   expect_match(trace[[1]], "^# [[:xdigit:]]+$")
-
-  skip("Logging not yet working see mrc-1683")
-  ## Check logging:
-  res$headers[["Content-Type"]] <- "application/json"
-  res$body <- result
-  res$status <- 400
-  msg <- capture_messages(
-    hintr:::api_log_end(NULL, NULL, res, NULL))
-  expect_match(msg[[1]], "error-key: [a-z]{5}-[a-z]{5}-[a-z]{5}")
-  expect_match(msg[[2]], "error-detail: test error")
-  expect_match(msg[[3]], "error-trace: rrq:::rrq_worker_main")
 })
 
 test_that("model run can be cancelled", {

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -1,0 +1,38 @@
+test_that("validate errors", {
+  path <- system.file("schema/Response.schema.json", mustWork = TRUE,
+                      package = "hintr")
+  v <- jsonvalidate::json_validator(path, "ajv")
+
+  mock_id <- mockery::mock(scalar("fake_key"), cycle = TRUE)
+  f <- function(message, error, ...) {
+    with_mock("ids::proquint" = mock_id, {
+      tryCatch(
+        hintr_error(message, error, ...),
+        error = function(e) {
+          pkgapi:::pkgapi_process_error(e)
+        }
+      )
+    })
+  }
+
+  e1 <- f("msg", "ERROR")
+  expect_equal(e1$value$errors, list(
+    list(
+      error = scalar("ERROR"),
+      detail = scalar("msg"),
+      key = scalar("fake_key")
+    )
+  ))
+  expect_true(v(e1$body))
+
+  e2 <- f("msg", "ERROR", trace = c(scalar("test"), scalar("trace")))
+  expect_equal(e2$value$errors, list(
+    list(
+      error = scalar("ERROR"),
+      detail = scalar("msg"),
+      key = scalar("fake_key"),
+      trace = c(scalar("test"), scalar("trace"))
+    )
+  ))
+  expect_true(v(e2$body))
+})


### PR DESCRIPTION
This PR will
* Add key to all errors
* Return trace from the model run for any errors
* Add preroute + postserialize logging from hintr and test that they will work

I think after this we should be in a position to integrate hintr2 into hintr. Perhaps some integration test before then would be useful just to verify - i.e. run up both APIs and call all the endpoints with the Malawi data and check stuff matches