### PR TITLE
MRC-1756: Add 404 handler

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -180,7 +180,7 @@ endpoint_model_result <- function(queue) {
 endpoint_model_cancel <- function(queue) {
   response <- pkgapi::pkgapi_returning_json("ModelCancelResponse.schema",
                                             schema_root())
-  pkgapi::pkgapi_endpoint$new("GET",
+  pkgapi::pkgapi_endpoint$new("POST",
                               "/model/cancel/<id>",
                               model_cancel(queue),
                               returning = response,

--- a/R/api.R
+++ b/R/api.R
@@ -21,6 +21,7 @@ api_build <- function(queue) {
   api$handle(endpoint_hintr_stop(queue))
   api$registerHook("preroute", hintr:::api_preroute)
   api$registerHook("postserialize", hintr:::api_postserialize)
+  api$set404Handler(hintr2_404_handler)
   api
 }
 

--- a/R/errors.R
+++ b/R/errors.R
@@ -3,3 +3,21 @@ hintr_error <- function(message, error, status_code = 400L, ...) {
   pkgapi::pkgapi_stop(message, error, errors = NULL, status_code = status_code,
                       key = key, ...)
 }
+
+hintr2_404_handler <- function(req, res) {
+  ## Manually construct the response here
+  res$status <- 404L
+  message <- tr_("ERROR_404",
+                 list(verb = req$REQUEST_METHOD, path = req$PATH_INFO))
+  list(
+    status = scalar("failure"),
+    errors = list(
+      list(
+        error = scalar("NOT_FOUND"),
+        detail = scalar(message),
+        key = scalar(ids::proquint(n_words = 3))
+      )
+    ),
+    data = NULL
+  )
+}

--- a/inst/schema/ChoroplethIndicatorMetadata.schema.json
+++ b/inst/schema/ChoroplethIndicatorMetadata.schema.json
@@ -4,6 +4,8 @@
   "properties": {
     "indicator": { "type": "string" },
     "value_column": { "type": "string" },
+    "error_low_column": { "type": "string" },
+    "error_high_column": { "type": "string" },
     "indicator_column": { "type": "string" },
     "indicator_value": { "type": "string" },
     "name": { "type": "string" },

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -982,6 +982,8 @@ test_that("api can call endpoint_hintr_stop", {
 
 
 test_that("404 errors have sensible schema", {
+  test_redis_available()
+
   queue <- test_queue()
   api <- api_build(queue)
   res <- api$request("GET", "/meaning-of-life")

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -958,7 +958,7 @@ test_that("api can call endpoint_hintr_worker_status", {
 test_that("endpoint_hintr_stop works", {
   test_redis_available()
 
-  queue <- test_queue(workers = 0)
+  queue <- test_queue()
   mock_hintr_stop <- mockery::mock(function() NULL)
   mockery::stub(endpoint_hintr_stop, "hintr_stop", mock_hintr_stop)
   endpoint <- endpoint_hintr_stop(queue)
@@ -970,7 +970,7 @@ test_that("endpoint_hintr_stop works", {
 test_that("api can call endpoint_hintr_stop", {
   test_redis_available()
 
-  queue <- test_queue(workers = 0)
+  queue <- test_queue()
   mock_hintr_stop <- mockery::mock(function() NULL)
   with_mock("hintr2:::hintr_stop" = mock_hintr_stop, {
     api <- api_build(queue)
@@ -978,4 +978,19 @@ test_that("api can call endpoint_hintr_stop", {
   })
   expect_equal(res$status, 200)
   mockery::expect_called(mock_hintr_stop, 1)
+})
+
+
+test_that("404 errors have sensible schema", {
+  queue <- test_queue()
+  api <- api_build(queue)
+  res <- api$request("GET", "/meaning-of-life")
+
+  expect_equal(res$status, 404)
+  response <- jsonlite::fromJSON(res$body)
+  expect_equal(response$status, "failure")
+  expect_equal(response$errors[1, "error"], "NOT_FOUND")
+  expect_equal(response$errors[1, "detail"],
+               "GET /meaning-of-life is not a valid hintr path")
+  expect_equal(response$data, NULL)
 })

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -992,5 +992,5 @@ test_that("404 errors have sensible schema", {
   expect_equal(response$errors[1, "error"], "NOT_FOUND")
   expect_equal(response$errors[1, "detail"],
                "GET /meaning-of-life is not a valid hintr path")
-  expect_equal(response$data, NULL)
+  expect_equal(response$data, setNames(list(), list()))
 })

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -541,7 +541,7 @@ test_that("api can call endpoint_model_cancel", {
   expect_equal(body$status, "success")
   expect_true(!is.null(body$data$id))
 
-  res <- api$request("GET", sprintf("/model/cancel/%s", body$data$id))
+  res <- api$request("POST", sprintf("/model/cancel/%s", body$data$id))
   expect_equal(res$status, 200)
   body <- jsonlite::fromJSON(res$body)
 


### PR DESCRIPTION
This PR will
* Add 404 handler which matches schema from current hintr
* Update ChoroplethIndicatorMetadata schema with changes from hintr
* Switches `/model/cancel` endpoint from `GET` to a `POST` - I think this some copy + paste error that I missed when adding the endpoint

This should bring us in line with hintr and mean we can start integrating these changes back into hintr repo.